### PR TITLE
Added config option for the harvester behavior

### DIFF
--- a/src/main/java/com/possible_triangle/sliceanddice/mixins/HarvesterMovementBehaviourMixin.java
+++ b/src/main/java/com/possible_triangle/sliceanddice/mixins/HarvesterMovementBehaviourMixin.java
@@ -2,6 +2,7 @@ package com.possible_triangle.sliceanddice.mixins;
 
 import com.google.common.base.Suppliers;
 import com.possible_triangle.sliceanddice.compat.ModCompat;
+import com.possible_triangle.sliceanddice.config.Configs;
 import com.simibubi.create.content.contraptions.actors.harvester.HarvesterMovementBehaviour;
 import net.minecraft.world.item.ItemStack;
 import org.spongepowered.asm.mixin.Mixin;
@@ -23,7 +24,11 @@ public class HarvesterMovementBehaviourMixin {
             at = @At(value = "STORE", ordinal = 0)
     )
     private ItemStack overwriteDefaultItem(ItemStack stack) {
-        return sliceanddice$TOOL.get();
+        if(Configs.INSTANCE.getSERVER().getHARVESTER_USES_KNIFE().get()) {
+            return sliceanddice$TOOL.get();
+        } else {
+            return stack;
+        }
     }
 
 }

--- a/src/main/kotlin/com/possible_triangle/sliceanddice/config/ServerConfig.kt
+++ b/src/main/kotlin/com/possible_triangle/sliceanddice/config/ServerConfig.kt
@@ -4,6 +4,8 @@ import net.minecraftforge.common.ForgeConfigSpec
 
 class ServerConfig(builder: ForgeConfigSpec.Builder) {
 
+    val HARVESTER_USES_KNIFE = builder.define("harvester.uses_knife", true)
+
     val CONSUME_DURABILTY = builder.define("slicer.consume_tool_durability", true)
     val IGNORE_ROTATION = builder.define("slicer.ignore_rotation", false)
     val SHOW_CONVERTED_RECIPES = builder.define("slicer.jei_show_converted_recipes", false)


### PR DESCRIPTION
Added config option for the `HarvesterMovementBehavior` mixin: `harvester.uses_knife`.
It is set to `true` by default since this has been the default behavior.
Inside the `HarvesterMovementBehaviorMixin` class, it simply checks against the config option and, if it finds that it is set to `false`, it returns the `ItemStack` unchanged.
I tested it on my mc world and it works without issues :D