### PR TITLE
CEI Liquid experience compatibility with Sprinkler

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,6 +10,7 @@ val flywheel_version: String by extra
 val jei_version: String by extra
 val kubejs_version: String by extra
 val farmers_delight_version: String by extra
+val create_enchantment_industry_version: String by extra
 val mixin_extras_version: String by extra
 
 plugins {
@@ -97,6 +98,7 @@ dependencies {
     implementation("io.github.llamalad7:mixinextras-forge:${mixin_extras_version}")
 
     modImplementation("curse.maven:farmers-delight-398521:${farmers_delight_version}")
+    modImplementation("curse.maven:create-enchantment-industry-688768:${create_enchantment_industry_version}")
     //modImplementation("curse.maven:overweight-farming-591666:${overweight_farming_version}")
 
     compileOnly("dev.latvian.mods:kubejs-forge:${kubejs_version}")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -127,6 +127,7 @@ uploadToCurseforge {
     dependencies {
         required("create")
         optional("farmers-delight")
+        optional("create-enchantment-industry")
         optional("overweight-farming")
     }
 }
@@ -135,6 +136,7 @@ uploadToModrinth {
     dependencies {
         required("LNytGWDc")
         optional("R2OftAxM")
+        optional("JWGBpFUP")
     }
 
     syncBodyFromReadme()

--- a/gradle.properties
+++ b/gradle.properties
@@ -23,6 +23,7 @@ mixin_extras_version=0.4.1
 kubejs_version=2001.6.5-build.20
 
 farmers_delight_version=4638874
+create_enchantment_industry_version=6405940
 #blueprint_version=6.1.0
 #neapolitan_version=4023083
 #overweight_farming_version=4395450

--- a/src/main/kotlin/com/possible_triangle/sliceanddice/Content.kt
+++ b/src/main/kotlin/com/possible_triangle/sliceanddice/Content.kt
@@ -11,7 +11,6 @@ import com.possible_triangle.sliceanddice.block.sprinkler.behaviours.FertilizerB
 import com.possible_triangle.sliceanddice.block.sprinkler.behaviours.MoistBehaviour
 import com.possible_triangle.sliceanddice.block.sprinkler.behaviours.PotionBehaviour
 import com.possible_triangle.sliceanddice.compat.CreateEnchantmentIndustryCompat
-import com.possible_triangle.sliceanddice.compat.ModCompat
 import com.possible_triangle.sliceanddice.config.Configs
 import com.possible_triangle.sliceanddice.recipe.CuttingProcessingRecipe
 import com.simibubi.create.AllBlocks

--- a/src/main/kotlin/com/possible_triangle/sliceanddice/Content.kt
+++ b/src/main/kotlin/com/possible_triangle/sliceanddice/Content.kt
@@ -10,6 +10,8 @@ import com.possible_triangle.sliceanddice.block.sprinkler.behaviours.BurningBeha
 import com.possible_triangle.sliceanddice.block.sprinkler.behaviours.FertilizerBehaviour
 import com.possible_triangle.sliceanddice.block.sprinkler.behaviours.MoistBehaviour
 import com.possible_triangle.sliceanddice.block.sprinkler.behaviours.PotionBehaviour
+import com.possible_triangle.sliceanddice.compat.CreateEnchantmentIndustryCompat
+import com.possible_triangle.sliceanddice.compat.ModCompat
 import com.possible_triangle.sliceanddice.config.Configs
 import com.possible_triangle.sliceanddice.recipe.CuttingProcessingRecipe
 import com.simibubi.create.AllBlocks
@@ -184,6 +186,7 @@ object Content {
         SprinkleBehaviour.register(HOT_FLUIDS, BurningBehaviour)
         SprinkleBehaviour.register(FERTILIZERS, FertilizerBehaviour)
         SprinkleBehaviour.register({ AllFluids.POTION.`is`(it.fluid) }, PotionBehaviour)
+        CreateEnchantmentIndustryCompat.ifLoaded { registerSprinkleBehaviour() }
     }
 
 }

--- a/src/main/kotlin/com/possible_triangle/sliceanddice/block/sprinkler/SprinkleBehaviour.kt
+++ b/src/main/kotlin/com/possible_triangle/sliceanddice/block/sprinkler/SprinkleBehaviour.kt
@@ -10,7 +10,11 @@ import net.minecraft.world.entity.Entity
 import net.minecraft.world.level.entity.EntityTypeTest
 import net.minecraft.world.level.material.Fluid
 import net.minecraft.world.phys.AABB
+import net.minecraft.world.phys.shapes.CollisionContext
+import net.minecraft.world.phys.shapes.Shapes
+import net.minecraft.world.phys.shapes.Shapes.DoubleLineConsumer
 import net.minecraftforge.fluids.FluidStack
+import kotlin.math.abs
 import kotlin.math.ceil
 import kotlin.math.floor
 
@@ -44,6 +48,33 @@ fun interface SprinkleBehaviour {
                 floor(aabb.maxX).toInt(), floor(aabb.maxY).toInt(), floor(aabb.maxZ).toInt(),
             )) {
                 consumer(block)
+            }
+        }
+
+        fun forEachGroundBlock(consumer: (BlockPos) -> Unit) {
+            val minX = ceil(aabb.minX).toInt()
+            val maxX = floor(aabb.maxX).toInt()
+            val minZ = ceil(aabb.minZ).toInt()
+            val maxZ = floor(aabb.maxZ).toInt()
+            val minY = ceil(aabb.minY).toInt()
+            val maxY = floor(aabb.maxY).toInt()
+
+            for (x in minX..maxX) {
+                horiz@
+                for (z in minZ..maxZ) {
+                    var y = maxY + 1
+                    vert@
+                    while (y > minY) {
+                        y--
+                        val pos = BlockPos(x, y, z)
+                        val state = world.getBlockState(pos)
+                        val shape = state.getCollisionShape(world, pos, CollisionContext.empty())
+
+                        if (y == minY) { consumer(pos); continue@horiz }
+                        if (state.isAir || shape.isEmpty) { continue@vert }
+                        if (shape.equals(Shapes.block())) { consumer(pos); continue@horiz }
+                    }
+                }
             }
         }
 

--- a/src/main/kotlin/com/possible_triangle/sliceanddice/block/sprinkler/SprinkleBehaviour.kt
+++ b/src/main/kotlin/com/possible_triangle/sliceanddice/block/sprinkler/SprinkleBehaviour.kt
@@ -12,9 +12,7 @@ import net.minecraft.world.level.material.Fluid
 import net.minecraft.world.phys.AABB
 import net.minecraft.world.phys.shapes.CollisionContext
 import net.minecraft.world.phys.shapes.Shapes
-import net.minecraft.world.phys.shapes.Shapes.DoubleLineConsumer
 import net.minecraftforge.fluids.FluidStack
-import kotlin.math.abs
 import kotlin.math.ceil
 import kotlin.math.floor
 

--- a/src/main/kotlin/com/possible_triangle/sliceanddice/compat/CreateEnchantmentIndustryCompat.kt
+++ b/src/main/kotlin/com/possible_triangle/sliceanddice/compat/CreateEnchantmentIndustryCompat.kt
@@ -1,0 +1,71 @@
+package com.possible_triangle.sliceanddice.compat
+
+import com.possible_triangle.sliceanddice.block.sprinkler.SprinkleBehaviour
+import com.possible_triangle.sliceanddice.config.Configs
+import net.minecraft.core.BlockPos
+import net.minecraft.server.level.ServerLevel
+import net.minecraft.util.RandomSource
+import net.minecraft.world.entity.player.Player
+import net.minecraft.world.phys.Vec3
+import net.minecraftforge.fluids.FluidStack
+import plus.dragons.createenchantmentindustry.content.contraptions.fluids.experience.ExperienceFluid
+import plus.dragons.createenchantmentindustry.entry.CeiFluids
+import kotlin.math.roundToInt
+
+class CreateEnchantmentIndustryCompat private constructor() : SprinkleBehaviour {
+    companion object {
+        private val INSTANCE = CreateEnchantmentIndustryCompat()
+
+        fun ifLoaded(runnable: CreateEnchantmentIndustryCompat.() -> Unit) {
+            ModCompat.ifLoaded(ModCompat.CREATE_ENCHANTMENT_INDUSTRY) {
+                runnable(INSTANCE)
+            }
+        }
+    }
+
+    override fun act(
+        range: SprinkleBehaviour.Range,
+        world: ServerLevel,
+        fluidStack: FluidStack,
+        random: RandomSource
+    ) {
+        // The following code is evil!!!
+        // This is an implementation detail of SprinkleTile.kt
+        // Everytime some fluid is used by the sprinkler, the processingTicks value is set to 20
+        // But the act function is only called when processingTicks is >= 8
+        // This effectively means this function executes for 13 consecutive ticks
+        // and then doesn't for 9 ticks
+        // We keep this into account to calculate the amount of fluid used each update
+        val fluidUsed = Configs.SERVER.SPRINKLER_USAGE.get()
+        val actingTicks = 13.toFloat()
+        val players = range.getEntities(Player::class.java)
+        val experienceFluid = fluidStack.fluid as ExperienceFluid
+
+        if (players.isEmpty()) {
+            val blocks = ArrayList<BlockPos>()
+            range.forEachGroundBlock { pos ->
+                if(random.nextFloat() <= 0.25) {
+                    blocks.add(pos);
+                }
+            }
+            val fluidToDrop = (fluidUsed.toFloat() / actingTicks) / blocks.size.toFloat()
+            blocks.forEach { pos ->
+                experienceFluid.drop(world, pos.center, fluidToDrop.roundToInt())
+            }
+        } else {
+            val fluidPerPlayer = (fluidUsed.toFloat() / actingTicks) / players.size.toFloat()
+            players.forEach { player ->
+                experienceFluid.awardOrDrop(player, world, player.position(), Vec3.ZERO, fluidPerPlayer.roundToInt())
+            }
+        }
+
+    }
+
+    fun registerSprinkleBehaviour() {
+        SprinkleBehaviour.register({
+            it.fluid.fluidType == CeiFluids.EXPERIENCE.type ||
+            it.fluid.fluidType == CeiFluids.HYPER_EXPERIENCE.type
+       }, INSTANCE)
+    }
+
+}

--- a/src/main/kotlin/com/possible_triangle/sliceanddice/compat/ModCompat.kt
+++ b/src/main/kotlin/com/possible_triangle/sliceanddice/compat/ModCompat.kt
@@ -20,6 +20,7 @@ interface IRecipeInjector {
 object ModCompat : IRecipeInjector {
 
     const val FARMERS_DELIGHT = "farmersdelight"
+    const val CREATE_ENCHANTMENT_INDUSTRY = "create_enchantment_industry"
     const val OVERWEIGHT_FARMING = "overweight_farming"
 
     fun <T> ifLoaded(mod: String, runnable: () -> T): T? {

--- a/src/main/resources/META-INF/mods.toml
+++ b/src/main/resources/META-INF/mods.toml
@@ -33,6 +33,13 @@ updateJSONURL="https://api.modrinth.com/updates/slice-and-dice/forge_updates.jso
     side = "BOTH"
 
 [[dependencies.${mod_id}]]
+modId = "create_enchantment_industry"
+mandatory = false
+versionRange = "[1.3.0,)"
+ordering = "NONE"
+side = "BOTH"
+
+[[dependencies.${mod_id}]]
     modId="kotlinforforge"
     mandatory=true
     versionRange="[4.3.0,)"


### PR DESCRIPTION
This is not a big change but it has always bothered me that liquid experience from CEI didn't drop from the sprinkler.
This pull request contains the following:
- Added Create Enchantment Industry as an optional dependency for integration purposes
- Registered Liquid Experience and Liquid Hyper Experience with `SprinkleBehaviour`
- If any amount of players is within the entity range of the active sprinkler, the experience will be directly transferred.
- If no players are in range, the experience is dropped on the ground within the sprinkler's area of effect
- Added a new utility function to the Range class `forEachGroundBlock` that searches for ground in the sprinkler area

Let me know if any changes need to be made :D