### PR TITLE
FluidIngredient Refactor to support Create 6.0.7

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@ org.gradle.caching=true
 kotlin.code.style=official
 
 mc_version=1.21.1
-neoforge_version=21.1.152
+neoforge_version=21.1.213
 java_version=21
 
 mod_id=sliceanddice
@@ -16,9 +16,9 @@ maven_group=com.possible-triangle
 
 jei_version=19.21.0.247
 flywheel_version=1.0.2
-create_version=6.0.6-99
-ponder_version=1.0.56
-registrate_version=MC1.21-1.3.0+62
+create_version=6.0.7-159
+ponder_version=1.0.63
+registrate_version=MC1.21-1.3.0+67
 kotlin_forge_version=5.8.0
 
 farmers_delight_version=opCbq7uB

--- a/src/main/kotlin/com/possible_triangle/sliceanddice/block/slicer/SlicerBlockEntity.kt
+++ b/src/main/kotlin/com/possible_triangle/sliceanddice/block/slicer/SlicerBlockEntity.kt
@@ -248,7 +248,8 @@ class SlicerBlockEntity(type: BlockEntityType<*>, pos: BlockPos, state: BlockSta
         addToParticleItems(input.stack)
 
         val toProcess = if (canProcessInBulk()) input.stack else input.stack.copyWithCount(1)
-        val outputs = RecipeApplier.applyRecipeOn(level, toProcess, recipe)
+        val world = level ?: return false
+        val outputs = RecipeApplier.applyRecipeOn(world, toProcess, recipe, true)
         outputList?.addAll(outputs)
         consumeDurability()
         return true

--- a/src/main/kotlin/com/possible_triangle/sliceanddice/compat/MixingRecipeGenerator.kt
+++ b/src/main/kotlin/com/possible_triangle/sliceanddice/compat/MixingRecipeGenerator.kt
@@ -6,10 +6,10 @@ import com.possible_triangle.sliceanddice.config.Configs
 import com.simibubi.create.content.fluids.transfer.EmptyingRecipe
 import com.simibubi.create.content.kinetics.mixer.MixingRecipe
 import com.simibubi.create.content.processing.recipe.StandardProcessingRecipe
-import com.simibubi.create.foundation.fluid.FluidIngredient
 import net.minecraft.resources.ResourceLocation
 import net.minecraft.world.item.ItemStack
 import net.minecraft.world.item.crafting.Ingredient
+import net.minecraft.world.level.material.FlowingFluid
 import net.neoforged.neoforge.capabilities.Capabilities
 import net.neoforged.neoforge.fluids.FluidStack
 import net.neoforged.neoforge.fluids.capability.IFluidHandler
@@ -29,6 +29,7 @@ class MixingRecipeGenerator(private val emptyingRecipes: Collection<EmptyingReci
     private fun getFromFluidHandler(stack: ItemStack): FluidStack? =
         stack.getCapability(Capabilities.FluidHandler.ITEM)
             ?.drain(1000, IFluidHandler.FluidAction.SIMULATE)
+            ?.takeUnless { it.isEmpty }
 
     private fun resolveIngredient(stack: ItemStack): Either<FluidStack, ItemStack> {
         val fluid = getFromEmptying(stack) ?: getFromFluidHandler(stack)
@@ -113,14 +114,20 @@ data class Ingredients(val items: List<Ingredient>, val fluids: List<FluidStack>
     }
 
     fun createRecipe(id: ResourceLocation, cookTime: Int, output: ItemStack): MixingRecipe {
-        val fluidIngredients = fluids.map { FluidIngredient.fromFluidStack(it) }
-        return StandardProcessingRecipe.Builder(::MixingRecipe, id)
+        val builder = StandardProcessingRecipe.Builder(::MixingRecipe, id)
             .withItemIngredients(*items.toTypedArray())
-            .withFluidIngredients(*fluidIngredients.toTypedArray())
             .requiresHeat(Configs.SERVER.COOKING_HEAT_CONDITION.get())
             .duration(cookTime)
             .withSingleItemOutput(output)
-            .build()
+        
+        fluids.forEach { fluidStack ->
+            val fluid = fluidStack.fluid
+            if (fluid is FlowingFluid) {
+                builder.require(fluid, fluidStack.amount)
+            }
+        }
+        
+        return builder.build()
     }
 
 }


### PR DESCRIPTION
### **Dependency Updates**

* Updated `neoforge_version`, `create_version`, `ponder_version`, and `registrate_version` in `gradle.properties` to the latest compatible versions.
  [[[1]](diffhunk://#diff-3d103fc7c312a3e136f88e81cef592424b8af2464c468116545c4d22d6edcf19L7-R7)](diffhunk://#diff-3d103fc7c312a3e136f88e81cef592424b8af2464c468116545c4d22d6edcf19L7-R7) [[[2]](diffhunk://#diff-3d103fc7c312a3e136f88e81cef592424b8af2464c468116545c4d22d6edcf19L19-R21)](diffhunk://#diff-3d103fc7c312a3e136f88e81cef592424b8af2464c468116545c4d22d6edcf19L19-R21)

### **Mixing Recipe Generation Refactor**

* Removed usage of Create’s deprecated `FluidIngredient.fromFluidStack` in `MixingRecipeGenerator.kt`.
* Implemented NeoForge-compatible fluid handling:

  * Directly iterates over each `FluidStack` and validates the fluid as a `FlowingFluid`.
  * Calls `builder.require(fluid, amount)` for each valid fluid to register it in the recipe.
* Replaced the old `.withFluidIngredients(...)` call with the new iterative builder approach.
* Added a new import for `net.minecraft.world.level.material.FlowingFluid` and removed the outdated `com.simibubi.create.foundation.fluid.FluidIngredient` import.