### PR TITLE
Fix NeoForge runtime packaging and compatibility

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -8,7 +8,7 @@ neoforge_version=21.1.219
 parchment_mappings_version=2024.11.17
 
 mod_id=sliceanddice
-mod_version=0.0.0-dev
+mod_version=4.3.1
 release_type=beta
 mod_name=Create Slice & Dice
 mod_author=possible_triangle

--- a/neoforge/build.gradle.kts
+++ b/neoforge/build.gradle.kts
@@ -16,7 +16,7 @@ dependencies {
 
     modApi(libs.registrate)
 
-    modIncludeCompileOnly(libs.atmosphere.api)
+    modIncludeCompileOnly(libs.atmosphere)
     modRuntimeOnly(libs.atmosphere)
 
     modApi(

--- a/neoforge/src/main/kotlin/com/possible_triangle/sliceanddice/Content.kt
+++ b/neoforge/src/main/kotlin/com/possible_triangle/sliceanddice/Content.kt
@@ -1,0 +1,21 @@
+package com.possible_triangle.sliceanddice
+
+import com.possible_triangle.sliceanddice.block.slicer.SlicerBlock
+import com.possible_triangle.sliceanddice.block.slicer.SlicerBlockEntity
+import com.possible_triangle.sliceanddice.index.SDBlockEntities
+import com.possible_triangle.sliceanddice.index.SDBlocks
+import com.tterrag.registrate.util.entry.BlockEntityEntry
+import com.tterrag.registrate.util.entry.BlockEntry
+
+/**
+ * Binary compatibility for integrations compiled against older Slice & Dice versions.
+ */
+@Deprecated("Use SDBlocks and SDBlockEntities instead")
+@Suppress("unused")
+object Content {
+    val SLICER_BLOCK: BlockEntry<SlicerBlock>
+        get() = SDBlocks.SLICER
+
+    val SLICER_BLOCK_ENTITY: BlockEntityEntry<SlicerBlockEntity>
+        get() = SDBlockEntities.SLICER
+}


### PR DESCRIPTION
## Summary

- Include the full NeoForge Atmosphere jar so the mod loads correctly on NeoForge `21.1.234`.
- Add back `com.possible_triangle.sliceanddice.Content` so existing integrations such as Create Encased can still access the slicer block and block entity.
- Set the NeoForge build version to `4.3.1` for this bugfix release.